### PR TITLE
fix: gen2spec.jq

### DIFF
--- a/gen2spec/gen2spec.jq
+++ b/gen2spec/gen2spec.jq
@@ -179,11 +179,13 @@ def clique:
 
     "blobSchedule" : (if .config.blobSchedule then ((
       (.config as $c | ["cancun", "prague", "osaka", "amsterdam", "bpo1", "bpo2", "bpo3", "bpo4", "bpo5"]
-      | map({ timestamp: $c[. + "Time"] } + $c.blobSchedule[.]))
+      | map(select($c.blobSchedule[.] != null) | { key: ., value: $c.blobSchedule[.] })
+      | map(select($c[.key + "Time"] != null)))
     )
     | reverse
-    | unique_by(.timestamp)
-    | map(select(length > 1))
+    | unique_by(.key)
+    | map({(.key): .value})
+    | add
     ) else null end),
 
     # Osaka


### PR DESCRIPTION
using image `nethermind/nethermind:1.32.2`, the resulting chainspec gave error:
```
" ---> System.Text.Json.JsonException: The JSON value could not be converted to System.Collections.Generic.Dictionary`2[System.String,Nethermind.Specs.ChainSpecStyle.Json.ChainSpecBlobCountJson]. Path: $.params.blobSchedule | LineNumber: 49 | BytePositionInLine: 21.
```
meaning it expected blobSchedule to be a dictionary rather than array.
so before change:
```
    "blobSchedule": {
      "cancun": {
        "target": 3,
        "max": 6,
        "baseFeeUpdateFraction": 3338477
      },
      "prague": {
        "target": 6,
        "max": 9,
        "baseFeeUpdateFraction": 5007716
      }
    }
```
was converted to:
```
    "blobSchedule": [
      {
        "timestamp": 0,
        "target": 3,
        "max": 6,
        "baseFeeUpdateFraction": 3338477
      }
    ],
```

and **after change in PR**:
```
"blobSchedule": {
      "cancun": {
        "target": 3,
        "max": 6,
        "baseFeeUpdateFraction": 3338477
      }
    },
```